### PR TITLE
Fix timestamp format

### DIFF
--- a/lib/Pasargad.js
+++ b/lib/Pasargad.js
@@ -202,10 +202,8 @@ module.exports = class Pasargad
     }
 
     getTimestamp() {
-        let d = new Date();
-        // "f*** javascript!" by example:
-        let dateString = d.getFullYear() + "-" + ("0"+(d.getMonth()+1)).slice(-2) +"-"+("0" + d.getDate()).slice(-2)+" "+("0" + d.getHours()).slice(-2)+":"+("0" + d.getMinutes()).slice(-2)+":"+("0" + d.getSeconds()).slice(-2);
-        return dateString;
+        const currentDateISO = new Date().toISOString();
+        return currentDateISO.replace(/-/g, '/').replace('T', ' ').replace('Z', '').split('.')[0];
     }
 
     async getToken(params)


### PR DESCRIPTION
The current timestamp function is producing:  `yyyy-mm-dd hh:mm:ss`
Which is not sync with the document format: `yyyy/mm/dd hh:mm:ss`

I've simply changed the formatting process of the `getTimestamp` function.